### PR TITLE
Upgrade ruby to 2.6-alpine, update serverspec and rubocop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:2.4.2
+FROM ruby:2.6-alpine
 
-ENV SERVERSPEC_VERSION 2.41.0
-ENV RUBOCOP_VERSION 0.50.0
+ENV SERVERSPEC_VERSION 2.41.3
+ENV RUBOCOP_VERSION 0.67.2
 
 RUN gem install serverspec -v ${SERVERSPEC_VERSION} && \
     gem install rubocop -v ${RUBOCOP_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ruby:2.6-alpine
 ENV SERVERSPEC_VERSION 2.41.3
 ENV RUBOCOP_VERSION 0.67.2
 
-RUN gem install serverspec -v ${SERVERSPEC_VERSION} --no-ri --no-rdoc && \
-    gem install rubocop -v ${RUBOCOP_VERSION} --no-ri --no-rdoc
+RUN apk add --no-cache build-base && \
+    gem install serverspec -v ${SERVERSPEC_VERSION} --no-document && \
+    gem install rubocop -v ${RUBOCOP_VERSION} --no-document
 
 WORKDIR /serverspec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV RUBOCOP_VERSION 0.67.2
 
 RUN apk add --no-cache build-base && \
     gem install serverspec -v ${SERVERSPEC_VERSION} --no-document && \
-    gem install rubocop -v ${RUBOCOP_VERSION} --no-document
+    gem install rubocop -v ${RUBOCOP_VERSION} --no-document && \
+    gem install ed25519 bcrypt_pbkdf --no-document
 
 WORKDIR /serverspec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ruby:2.6-alpine
 ENV SERVERSPEC_VERSION 2.41.3
 ENV RUBOCOP_VERSION 0.67.2
 
-RUN gem install serverspec -v ${SERVERSPEC_VERSION} && \
-    gem install rubocop -v ${RUBOCOP_VERSION}
+RUN gem install serverspec -v ${SERVERSPEC_VERSION} --no-ri --no-rdoc && \
+    gem install rubocop -v ${RUBOCOP_VERSION} --no-ri --no-rdoc
 
 WORKDIR /serverspec
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With Serverspec, you can write RSpec tests for checking your servers are configu
 
 [**Trusted Build**](https://hub.docker.com/r/uzyexe/serverspec/)
 
-This Docker image is based on the [ruby:2.4.2](https://hub.docker.com/_/ruby/) base image.
+This Docker image is based on the [ruby:2.6-alpine](https://hub.docker.com/_/ruby/) base image.
 
 ## Using
 


### PR DESCRIPTION
Hi,

Thanks for providing this image.
Would it be possible to accept the following changes please?
* Switch to using alpine for smaller images (I added build-base to build the native gems but we can probably restric it even more) - the final image is 85M
* upgrade serverspec and rubocop (to the latest)
* upgrade ruby to 2.6
* do not install the documentation

That's what this PR provides.
Note: If you merge, feel free to use the squash and merge option. I pushed them separately in case you were already reviewing them.
Thanks!
Joseph